### PR TITLE
Support .local hostnames using mDNS

### DIFF
--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -125,6 +125,7 @@ Hostnames that resolve to [non-public addresses](https://wicg.github.io/cors-rfc
 
 Thus connections to a loopback address (`127.0.0.0/8`, `::1/128`), a private network address (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `fc00::/7`) or a link-local address (`169.254.0.0/16`, `fe80::/10`) will fail unless a raw IP address is entered by the user.
 
+An exception will be hostnames ending with ".local" - these are resolved using [mDNS](https://tools.ietf.org/html/rfc6762).
 
 
 ### Threat

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -122,11 +122,12 @@ An attacker might configure DNS entries to point to private addresses in the use
 #### Mitigation
 
 Hostnames that resolve to [non-public addresses](https://wicg.github.io/cors-rfc1918/#framework) would be rejected.
+An exception is made for hostnames ending with `.local` - these are resolved using [mDNS](https://tools.ietf.org/html/rfc6762).
 
-Thus connections to a loopback address (`127.0.0.0/8`, `::1/128`), a private network address (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `fc00::/7`) or a link-local address (`169.254.0.0/16`, `fe80::/10`) will fail unless a raw IP address is entered by the user.
+Thus connections to a loopback address (`127.0.0.0/8`, `::1/128`), a private network address (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `fc00::/7`) or a link-local address (`169.254.0.0/16`, `fe80::/10`) will fail unless a raw IP address or a `*.local` hostname is entered by the user.
 
-An exception will be hostnames ending with ".local" - these are resolved using [mDNS](https://tools.ietf.org/html/rfc6762).
-
+For example, if the user enters `lights.example.com` and this resolves to `192.168.12.34`, we reject the connection attempt.
+If the user enters `lights.local`, and mDNS resolves this to `192.168.12.34`, the connection is allowed to proceed, just as if the user had typed `192.168.12.34`.
 
 ### Threat
 


### PR DESCRIPTION
Users can connect to devices that use .local hostnames,
where such hostnames are resolved using mDNS
https://tools.ietf.org/html/rfc6762

closes #23